### PR TITLE
Add secret env var handling

### DIFF
--- a/src/main/groovy/com/pearson/deployment/config/bitesize/EnvVar.groovy
+++ b/src/main/groovy/com/pearson/deployment/config/bitesize/EnvVar.groovy
@@ -16,7 +16,7 @@ class EnvVar implements Serializable {
     }
 
     EnvVar other = (EnvVar)obj
-    if (name == other.name && value == other.value) {
+    if (name == other.name && value == other.value && secret == other.secret) {
       return true
     }
     return false

--- a/src/main/groovy/com/pearson/deployment/config/bitesize/EnvVar.groovy
+++ b/src/main/groovy/com/pearson/deployment/config/bitesize/EnvVar.groovy
@@ -3,6 +3,7 @@ package com.pearson.deployment.config.bitesize
 class EnvVar implements Serializable {
   String name
   String value
+  String secret
 
   boolean equals(Object obj) {
 
@@ -22,6 +23,10 @@ class EnvVar implements Serializable {
   }
 
   LinkedHashMap asMap() {
-    [ name: name, value: value ]
+    if ( secret != null ) {
+      [ name: secret, valueFrom: [secretKeyRef: [name: value, key: value]]]
+    } else {
+      [ name: name, value: value ]
+    }
   }
 }

--- a/src/main/groovy/com/pearson/deployment/config/kubernetes/KubeContainer.groovy
+++ b/src/main/groovy/com/pearson/deployment/config/kubernetes/KubeContainer.groovy
@@ -24,7 +24,11 @@ class KubeContainer {
     }
 
     env = o.env.collect { var ->
-      new EnvVar(name: var.name, value: var.value)
+      if (var.secret) {
+        new EnvVar(secret: var.secret, value: var.value)
+      } else {
+        new EnvVar(name: var.name, value: var.value)
+      }
     }
   }
 
@@ -39,7 +43,7 @@ class KubeContainer {
     }
 
     def obj = (KubeContainer)o
-    
+
     (this.name == obj.name) &&
     (this.image == obj.image) &&
     (this.ports == obj.ports) &&
@@ -48,7 +52,7 @@ class KubeContainer {
     (this.env == obj.env)
   }
 
-  LinkedHashMap asMap() { 
+  LinkedHashMap asMap() {
     [
       "name": name,
       "image": image,

--- a/src/main/groovy/com/pearson/deployment/config/kubernetes/KubeContainer.groovy
+++ b/src/main/groovy/com/pearson/deployment/config/kubernetes/KubeContainer.groovy
@@ -24,11 +24,7 @@ class KubeContainer {
     }
 
     env = o.env.collect { var ->
-      if (var.secret) {
-        new EnvVar(secret: var.secret, value: var.value)
-      } else {
-        new EnvVar(name: var.name, value: var.value)
-      }
+      new EnvVar(name: var.name, secret: var.secret, value: var.value)
     }
   }
 


### PR DESCRIPTION
Add loading env var from a secret in the target deployment's namespace.

Example:

```
        env:
          - name: APP_PORT
            value: 80
          - secret: CONSUL_TOKEN
            value: consul-test-app-dev-read
```

Validate:

1. create namespace test-app-dev using stackstorm bitesize.create_ns workflow with git@github.com:devlinmr/test-app-v2.git as the repo
2. Deploy test app:
```
git clone github.com:devlinmr/test-app-v2.git
_edit kube/*.yaml as needed_
kubectl create -f kube/jenkins-deployment.yaml
kubectl create -f kube/jenkins-svc.yaml
kubectl create -f kube/jenkins-ing.yaml
```
3. Observe CONSUL_TOKEN env var is populated with the appropriate secret value:
```
kubectl exec -ti front-1885382652-okdnp --namespace=test-app-dev env | grep CONSUL
CONSUL_TOKEN=230ecf3d-ce63-88e4-31fa-8b50aca778c4
```